### PR TITLE
feat: generate integration testing class thanks to gateway sdk

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,11 +23,12 @@ Suppose you want to create a Policy that control if request contains the ``X-Foo
 mvn archetype:generate\
  -DarchetypeGroupId=io.gravitee.maven.archetypes\
  -DarchetypeArtifactId=gravitee-policy-maven-archetype\
- -DarchetypeVersion=1.9.0\
+ -DarchetypeVersion=1.10.0\
  -DartifactId=foo-header-check-policy\
  -DgroupId=my.gravitee.extension.policy\
  -Dversion=1.0.0-SNAPSHOT\
- -DpolicyName=FooHeaderCheck
+ -DpolicyName=FooHeaderCheck\
+ -DtestingGatewayVersion=3.18.0
 ```
 
 Once executed and parameters confirmed, the above command will create the ``foo-header-check-policy`` directory containing the following structure:

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>io.gravitee.maven.archetypes</groupId>
     <artifactId>gravitee-policy-maven-archetype</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.0-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>Gravitee.io APIM - Policy - Maven archetype</name>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -8,6 +8,9 @@
         <requiredProperty key="policyName">
             <defaultValue>Simple</defaultValue>
         </requiredProperty>
+        <requiredProperty key="testingGatewayVersion">
+            <defaultValue>3.18.0</defaultValue>
+        </requiredProperty>
     </requiredProperties>
 
     <fileSets>
@@ -27,6 +30,18 @@
             <directory>src/test/java</directory>
             <includes>
                 <include>**/*.java</include>
+            </includes>
+        </fileSet>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/test/resources</directory>
+            <includes>
+                <include>**/*.xml</include>
+            </includes>
+        </fileSet>
+        <fileSet filtered="true" packaged="true" encoding="UTF-8">
+            <directory>src/test/resources</directory>
+            <includes>
+                <include>**/*.json</include>
             </includes>
         </fileSet>
         <fileSet filtered="true" encoding="UTF-8">

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -30,34 +30,23 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.1</version>
+        <version>20.2</version>
     </parent>
 
     <properties>
-
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-apim-gateway-tests-sdk.version>${testingGatewayVersion}</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
+        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.25.0</gravitee-common.version>
-
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
-        <gravitee-bom.version>2.5</gravitee-bom.version>
-        <gravitee-apim-gateway-tests-sdk.version>${testingGatewayVersion}</gravitee-apim-gateway-tests-sdk.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
                 <groupId>io.gravitee</groupId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -30,20 +30,44 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <version>20.1</version>
     </parent>
 
     <properties>
 
-        <gravitee-gateway-api.version>1.24.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.20.0</gravitee-common.version>
+        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.25.0</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-apim-gateway-tests-sdk.version>${testingGatewayVersion}</gravitee-apim-gateway-tests-sdk.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -71,21 +95,44 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/archetype-resources/src/main/resources/plugin.properties
+++ b/src/main/resources/archetype-resources/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-id=${symbol_dollar}{project.artifactId}
+id=${policyName}
 name=${policyName}
 version=${symbol_dollar}{project.version}
 description=${symbol_dollar}{project.description}

--- a/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyIntegrationTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyIntegrationTest.java
@@ -84,7 +84,7 @@ public class ${policyName}PolicyIntegrationTest extends AbstractPolicyTest<${pol
     @Test
     @DisplayName("Should test the policy deployed on an in memory gateway")
     public void shouldTest${policyName}PolicyDeployedOnAnInMemoryGateway(WebClient client) throws Exception {
-        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+        wiremock.stubFor(get("/backend").willReturn(ok("response from backend")));
 
         final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
 
@@ -98,6 +98,6 @@ public class ${policyName}PolicyIntegrationTest extends AbstractPolicyTest<${pol
             })
         .assertNoErrors();
 
-        wiremock.verify(getRequestedFor(urlPathEqualTo("/team")).withHeader("X-DummyHeader", equalTo("${policyName}")));
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/backend")).withHeader("X-DummyHeader", equalTo("${policyName}")));
     }
 }

--- a/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyIntegrationTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyIntegrationTest.java
@@ -1,0 +1,103 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ${package}.${policyName}Policy;
+import ${package}.${policyName}PolicyConfiguration;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.util.Map;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Header1Policy;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.reactiverse.junit5.web.WebClientOptionsInject;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+@GatewayTest
+@DisplayName("Should do callout and set response as attribute")
+@DeployApi("/${packageInPathFormat}/apis/${policyName}.json")
+public class ${policyName}PolicyIntegrationTest extends AbstractPolicyTest<${policyName}Policy, ${policyName}PolicyConfiguration> {
+
+    // You can override configuration of the WebClient with the following lines.
+    // @WebClientOptionsInject
+    // public WebClientOptions options = new WebClientOptions().setDefaultHost("localhost").setDefaultPort(gatewayPort());
+
+    @Override
+    public void configureApi(Api api) {
+        // Here you can override each api to deploy programmatically.
+    }
+
+    @Override
+    public void configureWireMock(WireMockConfiguration configuration) {
+        // Here you can override the wiremock configuration. Wiremock is the component mocking your backends.
+    }
+
+    @Override
+    public void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        // Here you can override the gateway configuration if needed.
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        // Here you can register custom testing policies, for example:
+        policies.put("header-policy1", PolicyBuilder.build("header-policy1", Header1Policy.class));
+
+        // you have the same capabilities with:
+        // - configureConnectors(Map<String, ConnectorPlugin> connectors)
+        // - configureResources(Map<String, ResourcePlugin> resources)
+        // - configureReporters(Map<String, Reporter> reporters)
+    }
+
+    @Test
+    @DisplayName("Should test the policy deployed on an in memory gateway")
+    public void shouldTest${policyName}PolicyDeployedOnAnInMemoryGateway(WebClient client) throws Exception {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.bodyAsString()).isEqualTo("response from backend");
+                return true;
+            })
+        .assertNoErrors();
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/team")).withHeader("X-DummyHeader", equalTo("${policyName}")));
+    }
+}

--- a/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyTest.java
@@ -18,7 +18,7 @@
  */
 package ${package};
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ${policyName}PolicyTest {
 

--- a/src/main/resources/archetype-resources/src/test/resources/apis/__policyName__.json
+++ b/src/main/resources/archetype-resources/src/test/resources/apis/__policyName__.json
@@ -1,0 +1,42 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "policy": "${policyName}",
+          "name": "${policyName}",
+          "description": "${policyName} Description",
+          "configuration": {
+            "stringParam": "${policyName}"
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}

--- a/src/main/resources/archetype-resources/src/test/resources/apis/__policyName__.json
+++ b/src/main/resources/archetype-resources/src/test/resources/apis/__policyName__.json
@@ -7,7 +7,7 @@
     "endpoints": [
       {
         "name": "default",
-        "target": "http://localhost:8080/team",
+        "target": "http://localhost:8080/backend",
         "http": {
           "connectTimeout": 3000,
           "readTimeout": 60000

--- a/src/main/resources/archetype-resources/src/test/resources/logback-test.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>

--- a/src/test/resources/projects/dummy/archetype.properties
+++ b/src/test/resources/projects/dummy/archetype.properties
@@ -4,3 +4,4 @@ artifactId=dummy
 version=0.0.1-SNAPSHOT
 package=dummy.project
 policyName=Dummy
+testingGatewayVersion=3.18.0-SNAPSHOT


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7714

**Description**

Policy project is now generated using the APIM Gateway SDK.
It generates a working test class like this:


````
@GatewayTest
@DisplayName("Should do callout and set response as attribute")
@DeployApi("/dummy/project/apis/Dummy.json")
public class DummyPolicyIntegrationTest extends AbstractPolicyTest<DummyPolicy, DummyPolicyConfiguration> {

    // You can override configuration of the WebClient with the following lines.
    // @WebClientOptionsInject
    // public WebClientOptions options = new WebClientOptions().setDefaultHost("localhost").setDefaultPort(gatewayPort());

    @Override
    public void configureApi(Api api) {
        super.configureApi(api);
        // Here you can override each api to deploy programmatically.
    }

    @Override
    public void configureWireMock(WireMockConfiguration configuration) {
        // Here you can override the wiremock configuration. Wiremock is the component mocking your backends.
    }

    @Override
    public void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
        // Here you can override the gateway configuration if needed.
    }

    @Override
    public void configurePolicies(Map<String, PolicyPlugin> policies) {
        super.configurePolicies(policies);
        // Here you can register custom testing policies, for example:
        policies.put("header-policy1", PolicyBuilder.build("header-policy1", Header1Policy.class));

        // you have the same capabilities with:
        // - configureConnectors(Map<String, ConnectorPlugin> connectors)
        // - configureResources(Map<String, ResourcePlugin> resources)
        // - configureReporters(Map<String, Reporter> reporters)
    }

    @Test
    @DisplayName("Should test the policy deployed on an in memory gateway")
    public void shouldTestDummyPolicyDeployedOnAnInMemoryGateway(WebClient client) throws Exception {
        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));

        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();

        awaitTerminalEvent(obs);
        obs
            .assertComplete()
            .assertValue(response -> {
                assertThat(response.statusCode()).isEqualTo(200);
                assertThat(response.bodyAsString()).isEqualTo("response from backend");
                return true;
            })
        .assertNoErrors();

        wiremock.verify(getRequestedFor(urlPathEqualTo("/team")).withHeader("X-DummyHeader", equalTo("Dummy")));
    }
}
````
