### PR TITLE
fix: bump gateway-api dependency causing compatibility issues

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -30,14 +30,14 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>20.3</version>
     </parent>
 
     <properties>
         <gravitee-apim-gateway-tests-sdk.version>${testingGatewayVersion}</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.34.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyIntegrationTest.java
+++ b/src/main/resources/archetype-resources/src/test/java/__policyName__PolicyIntegrationTest.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 
 @GatewayTest
-@DisplayName("Should do callout and set response as attribute")
 @DeployApi("/${packageInPathFormat}/apis/${policyName}.json")
 public class ${policyName}PolicyIntegrationTest extends AbstractPolicyTest<${policyName}Policy, ${policyName}PolicyConfiguration> {
 


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.1-fix-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/maven/archetypes/gravitee-policy-maven-archetype/1.10.1-fix-dependencies-SNAPSHOT/gravitee-policy-maven-archetype-1.10.1-fix-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
